### PR TITLE
Fix x86_64 Wine build on Apple Silicon

### DIFF
--- a/scripts/build-wine.sh
+++ b/scripts/build-wine.sh
@@ -22,7 +22,7 @@
 #
 # Env: CX_VER (default 26.2.0), BUILD_DIR (default ./build), JOBS (default: all cores)
 
-set -uo pipefail
+set -euo pipefail
 CX_VER="${CX_VER:-26.2.0}"
 BUILD_DIR="${BUILD_DIR:-$(pwd)/build}"
 JOBS="${JOBS:-$(sysctl -n hw.ncpu)}"
@@ -84,6 +84,13 @@ cmd_configure() {
   arch -x86_64 /bin/bash -c '
     export PATH="'"$("$BREW" --prefix bison)"'/bin:$PATH"
     export MACOSX_DEPLOYMENT_TARGET=10.15
+    # On Apple Silicon, running Apple clang under Rosetta does not change its default
+    # target: it still emits arm64 code. Force the host objects to x86_64 explicitly,
+    # otherwise configure defines __x86_64__ alongside the clang __arm64__ default
+    # and the macOS SDK includes both architecture header families.
+    export CFLAGS="${CFLAGS:+$CFLAGS }-arch x86_64"
+    export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }-arch x86_64"
+    export LDFLAGS="${LDFLAGS:+$LDFLAGS }-arch x86_64"
     echo "host arch: $(uname -m); bison: $(bison --version | head -1)"
     cd "'"$WINE_BUILD"'"
     CC=clang CXX=clang++ "'"$WINE_SRC"'/configure" --enable-archs=x86_64 --disable-tests --without-x \
@@ -104,6 +111,9 @@ cmd_build() {
   [ -d "$WINE_BUILD" ] || { echo "run 'configure' first"; exit 1; }
   arch -x86_64 /bin/bash -c '
     export PATH="'"$("$BREW" --prefix bison)"'/bin:$PATH"; export MACOSX_DEPLOYMENT_TARGET=10.15
+    export CFLAGS="${CFLAGS:+$CFLAGS }-arch x86_64"
+    export CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }-arch x86_64"
+    export LDFLAGS="${LDFLAGS:+$LDFLAGS }-arch x86_64"
     cd "'"$WINE_BUILD"'" && make -j'"$JOBS"'
   ' 2>&1 | tee "$BUILD_DIR/build.log"
   echo ""


### PR DESCRIPTION
## What changed

- force host C, C++, and linker targets to x86_64 during configure and build
- stop the build script immediately when a pipeline command fails

## Why

On Apple Silicon with Xcode 26, running Apple clang under Rosetta still defaults
to an arm64 target. Wine's configure step then defines `__x86_64__` alongside
clang's `__arm64__`, causing the macOS SDK to include both architecture header
families and fail with duplicate `_OSSwapInt*` definitions.

Explicit `-arch x86_64` flags make the generated host tools and Unix modules
match the intended Rosetta target. Enabling `set -e` also prevents a failed
configure pipeline from continuing into `sed` and returning a misleading
success status.

## Validation

- `bash -n scripts/build-wine.sh`
- `git diff --check`
- configured CrossOver 26.2 Wine successfully on Apple M5 / macOS 26.5.2
- completed the full `make -j10` build
- verified x86_64 `ntdll.so`, `kernel32.dll`, and `ntoskrnl.exe`
- deployed and launched GRYPHLINK from the patched CrossOver copy
